### PR TITLE
Verwerken van DOM elementen verplaatst naar connected callback fase om zeker te zijn dat elementen aanwezig zijn

### DIFF
--- a/src/vl-rich-data.js
+++ b/src/vl-rich-data.js
@@ -85,15 +85,13 @@ export class VlRichData extends vlElement(HTMLElement) {
         </div>
       </div>
     `);
-
-    this.__processSearchFilter();
-    this.__processSorter();
-
-    this.__observePager();
-    this.__observeFilterButtons();
   }
 
   connectedCallback() {
+    this.__processSearchFilter();
+    this.__processSorter();
+    this.__observePager();
+    this.__observeFilterButtons();
     this._observer = this.__observeSearchFilter();
     this.__updateNumberOfSearchResults();
   }


### PR DESCRIPTION
In kader van #29 werd de logica verplaatst naar de `connectedCallback`. Er werden geen testen toegevoegd aangezien het blijkbaar geen probleem vormt op webcomponent niveau dan wel in combinatie met lit-html. Gevaar voor regressie, al blijft het best practice om pas in de `connectedCallback` fase de DOM elementen te manipuleren en zal hier over gewaakt worden in toekomstige PR's. Afnemers zijn vrij alsnog testen toe te voegen.