### PR TITLE
Revert mutation observer geïntroduceerd uit eerdere PR's

### DIFF
--- a/src/vl-rich-data.js
+++ b/src/vl-rich-data.js
@@ -340,7 +340,7 @@ export class VlRichData extends vlElement(HTMLElement) {
         this.__processSearchFilter();
       }
     });
-    observer.observe(this, {childList: true, subtree: true});
+    observer.observe(this, {childList: true});
     return observer;
   }
 


### PR DESCRIPTION
Uit eerdere PR's blijkt dat een `subtree` mutation observer overbodig is.